### PR TITLE
Add update_Q_A to MEX interface

### DIFF
--- a/QPALM/interfaces/mex/qpalm.m
+++ b/QPALM/interfaces/mex/qpalm.m
@@ -211,6 +211,24 @@ classdef qpalm < handle
             end
             qpalm.qpalm_mex('update_q', q);
         end
+		
+        function update_Q_A(this, Q, A)
+            % UPDATE_Q_A update the matrices Q and A
+            %
+            %   update_Q_A(Q, A)
+            
+            if (isempty(A))
+                A = sparse(this.m, this.n);
+            else
+                A = sparse(A);
+            end
+            if (isempty(Q))
+                Q = sparse(this.n, this.n);
+            else
+                Q = sparse(Q);
+            end
+            qpalm.qpalm_mex('update_Q_A', Q, A);
+        end
         
         function update_bounds(this, bmin, bmax)
             % UPDATE_BOUNDS update the lower and upper bounds of the linear

--- a/QPALM/interfaces/mex/qpalm.m
+++ b/QPALM/interfaces/mex/qpalm.m
@@ -231,7 +231,7 @@ classdef qpalm < handle
             else
                 Q = full(Q);
             end
-			Qxi = this.Q_sparsity & triu(true(this.n));
+            Qxi = this.Q_sparsity & triu(true(this.n));
             qpalm.qpalm_mex('update_Q_A', Q(Qxi), A(this.A_sparsity));
         end
         

--- a/QPALM/interfaces/mex/src/qpalm_mex.c
+++ b/QPALM/interfaces/mex/src/qpalm_mex.c
@@ -187,7 +187,7 @@ void mexFunction(int nlhs, mxArray * plhs [], int nrhs, const mxArray * prhs [])
     char cmd[64];
 
     if (nrhs < 1 || mxGetString(prhs[0], cmd, sizeof(cmd)))
-		mexErrMsgTxt("First input should be a command string less than 64 characters long.");
+        mexErrMsgTxt("First input should be a command string less than 64 characters long.");
     
     // report the default settings
     if (strcmp(cmd, MODE_DEFAULT_SETTINGS) == 0) {

--- a/QPALM/interfaces/mex/src/qpalm_mex.c
+++ b/QPALM/interfaces/mex/src/qpalm_mex.c
@@ -362,15 +362,7 @@ void mexFunction(int nlhs, mxArray * plhs [], int nrhs, const mxArray * prhs [])
         }
         
         if (!mxIsEmpty(prhs[1])) {
-            const mxArray* Q = prhs[1];
-            const mxArray* A = prhs[2];
-
-            solver_sparse Amatrix, Qmatrix;
-            ladel_get_sparse_from_matlab(A, &Amatrix, UNSYMMETRIC);
-            ladel_get_sparse_from_matlab(Q, &Qmatrix, UPPER);
-            ladel_to_upper_diag(&Qmatrix);
-
-            qpalm_update_Q_A(qpalm_work, Qmatrix.x, Amatrix.x);
+            qpalm_update_Q_A(qpalm_work, mxGetPr(prhs[1]), mxGetPr(prhs[2]));
         } else {
             mexWarnMsgTxt("Update Q and A: Empty Q has no effect.");
         }

--- a/QPALM/interfaces/mex/src/qpalm_mex.c
+++ b/QPALM/interfaces/mex/src/qpalm_mex.c
@@ -14,6 +14,7 @@
 #define MODE_WARM_START "warm_start"
 #define MODE_UPDATE_BOUNDS "update_bounds"
 #define MODE_UPDATE_LINEAR "update_q"
+#define MODE_UPDATE_MATRICES "update_Q_A"
 #define MODE_SOLVE "solve"
 #define MODE_DELETE "delete"
 
@@ -349,6 +350,29 @@ void mexFunction(int nlhs, mxArray * plhs [], int nrhs, const mxArray * prhs [])
             qpalm_update_q(qpalm_work, q);
         } else {
             mexWarnMsgTxt("Update q: Empty q has no effect.");
+        }
+
+    } else if (strcmp(cmd, MODE_UPDATE_MATRICES) == 0) {
+        
+        if (nlhs != 0 || nrhs != 3){
+            mexErrMsgTxt("Update Q and A : wrong number of inputs / outputs");
+        }
+        if(!qpalm_work){
+            mexErrMsgTxt("Work is not setup.");
+        }
+        
+        if (!mxIsEmpty(prhs[1])) {
+            const mxArray* Q = prhs[1];
+            const mxArray* A = prhs[2];
+
+            solver_sparse Amatrix, Qmatrix;
+            ladel_get_sparse_from_matlab(A, &Amatrix, UNSYMMETRIC);
+            ladel_get_sparse_from_matlab(Q, &Qmatrix, UPPER);
+            ladel_to_upper_diag(&Qmatrix);
+
+            qpalm_update_Q_A(qpalm_work, Qmatrix.x, Amatrix.x);
+        } else {
+            mexWarnMsgTxt("Update Q and A: Empty Q has no effect.");
         }
 
     } else if (strcmp(cmd, MODE_SOLVE) == 0) { // SOLVE


### PR DESCRIPTION
Adds the `update_Q_A` method to the MATLAB MEX interface since I use it a lot.
This code works in my limited testing for my limited use-case.